### PR TITLE
add menu items to control  scrolling effect  and  tooltip

### DIFF
--- a/table-of-contents-sidebar/_locales/en/messages.json
+++ b/table-of-contents-sidebar/_locales/en/messages.json
@@ -34,5 +34,17 @@
   },
   "integrate": {
     "message":"Integrate to your website"
+  },
+  "tooltip": {
+    "message": "show tooltip"
+  },
+  "untooltip": {
+    "message": "hide tooltip"
+  },
+  "scroll": {
+    "message": "scroll effect"
+  },
+  "unscroll": {
+    "message": "no scroll effect"
   }
 }

--- a/table-of-contents-sidebar/_locales/zh_CN/messages.json
+++ b/table-of-contents-sidebar/_locales/zh_CN/messages.json
@@ -34,5 +34,17 @@
   },
   "integrate": {
     "message":"集成到博客"
+  },
+  "tooltip": {
+    "message": "显示提示信息"
+  },
+  "untooltip": {
+    "message": "隐藏提示信息"
+  },
+  "scroll": {
+    "message": "使用滚动效果"
+  },
+  "unscroll": {
+    "message": "取消滚动效果"
   }
 }

--- a/table-of-contents-sidebar/app.js
+++ b/table-of-contents-sidebar/app.js
@@ -1,25 +1,50 @@
-chrome.storage.sync.get({
-    tocs_toggle: true,
-    scroll_effect:false,
-    show_tooltip:false
-}, function (items) {
-    var toggle = items.tocs_toggle;
-    var effect = items.scroll_effect;
-    var tooltip = items.show_tooltip;
-    if (!toggle) return;
-    TableOfContents.init({
-        basePath: chrome.extension.getURL("") + "table-of-contents-sidebar-lib/",
-        rightTooltip: chrome.i18n.getMessage("right"),
-        leftTooltip: chrome.i18n.getMessage("left"),
-        unpinTooltip: chrome.i18n.getMessage("unpin"),
-        pinTooltip: chrome.i18n.getMessage("pin"),
-        bugTooltip: chrome.i18n.getMessage("bug"),
-        sourcecodeTooltip: chrome.i18n.getMessage("sourcecode"),
-        rateusTooltip: chrome.i18n.getMessage("rateus"),
-        yitingTooltip: chrome.i18n.getMessage("yiting"),
-        majiangTooltip: chrome.i18n.getMessage("majiang"),
-        integrateBtnTooltip: chrome.i18n.getMessage("integrate"),
-        scrollEffect:effect,
-        showTooltip:tooltip
+function showToc() {
+    chrome.storage.sync.get({
+        tocs_toggle: true,
+        scroll_effect: false,
+        show_tooltip: false
+    }, function (items) {
+        var toggle = items.tocs_toggle;
+        var effect = items.scroll_effect;
+        var tooltip = items.show_tooltip;
+        if (!toggle) return;
+        TableOfContents.init({
+            basePath: chrome.extension.getURL("") + "table-of-contents-sidebar-lib/",
+            rightTooltip: chrome.i18n.getMessage("right"),
+            leftTooltip: chrome.i18n.getMessage("left"),
+            unpinTooltip: chrome.i18n.getMessage("unpin"),
+            pinTooltip: chrome.i18n.getMessage("pin"),
+            bugTooltip: chrome.i18n.getMessage("bug"),
+            sourcecodeTooltip: chrome.i18n.getMessage("sourcecode"),
+            rateusTooltip: chrome.i18n.getMessage("rateus"),
+            yitingTooltip: chrome.i18n.getMessage("yiting"),
+            majiangTooltip: chrome.i18n.getMessage("majiang"),
+            integrateBtnTooltip: chrome.i18n.getMessage("integrate"),
+            scrollEffect: effect,
+            showTooltip: tooltip
+        });
+        TableOfContents.activePin(); //默认pin的状态
     });
-});
+}
+var siderbar_id = "table-of-contents-sidebar-id";
+
+function hideToc() {
+    document.getElementById(siderbar_id).outerHTML = '';
+    document.getElementById("table-of-contents-sidebar-hover-menu-id").outerHTML = '';
+}
+
+function isAlreadyToc() {
+    var ele = document.getElementById(siderbar_id);
+    return !!ele;
+}
+
+chrome.runtime.onMessage.addListener(function (request, sender, sendRequest) {
+    if (request.type !== "toggleToc") {
+        return;
+    }
+    if (isAlreadyToc()) {
+        hideToc();
+    } else {
+        showToc();
+    }
+})

--- a/table-of-contents-sidebar/app.js
+++ b/table-of-contents-sidebar/app.js
@@ -1,7 +1,11 @@
 chrome.storage.sync.get({
-    tocs_toggle: true
+    tocs_toggle: true,
+    scroll_effect:false,
+    show_tooltip:false
 }, function (items) {
     var toggle = items.tocs_toggle;
+    var effect = items.scroll_effect;
+    var tooltip = items.show_tooltip;
     if (!toggle) return;
     TableOfContents.init({
         basePath: chrome.extension.getURL("") + "table-of-contents-sidebar-lib/",
@@ -14,6 +18,8 @@ chrome.storage.sync.get({
         rateusTooltip: chrome.i18n.getMessage("rateus"),
         yitingTooltip: chrome.i18n.getMessage("yiting"),
         majiangTooltip: chrome.i18n.getMessage("majiang"),
-        integrateBtnTooltip: chrome.i18n.getMessage("integrate")
+        integrateBtnTooltip: chrome.i18n.getMessage("integrate"),
+        scrollEffect:effect,
+        showTooltip:tooltip
     });
 });

--- a/table-of-contents-sidebar/background.js
+++ b/table-of-contents-sidebar/background.js
@@ -1,3 +1,51 @@
+
+//isMenuCreated: true: have been created
+function addMenu(isMenuCreated) {
+    if (!chrome.contextMenus) return;
+    if (!isMenuCreated) {
+        chrome.contextMenus.create({
+            id: "menu1",
+            title: "menu",
+            contexts: ["browser_action"]
+        });
+        chrome.contextMenus.create({
+            id: "menu2",
+            title: "menu",
+            contexts: ["browser_action"]
+        });
+    }
+
+    chrome.storage.sync.get({
+        scroll_effect: false
+    }, function (items) {
+        var scrollMsg = items.scroll_effect ? chrome.i18n.getMessage("unscroll") : chrome.i18n.getMessage("scroll");
+        chrome.contextMenus.update("menu1", {
+            title: scrollMsg,
+            onclick: function () {
+                chrome.storage.sync.set({ 'scroll_effect': !items.scroll_effect }, function () {
+                    addMenu(true);
+                    refresh();
+                });
+            }
+        });
+    });
+
+    chrome.storage.sync.get({
+        show_tooltip: false
+    }, function (items) {
+        var tooltipMsg = items.show_tooltip ? chrome.i18n.getMessage("untooltip") : chrome.i18n.getMessage("tooltip");
+        chrome.contextMenus.update("menu2", {
+            title: tooltipMsg,
+            onclick: function () {
+                chrome.storage.sync.set({ 'show_tooltip': !items.show_tooltip }, function () {
+                    addMenu(true);
+                    refresh();
+                });
+            }
+        });
+    });
+}
+
 function displayEnable() {
     if (!chrome.contextMenus) return;
     chrome.contextMenus.removeAll();
@@ -10,6 +58,7 @@ function displayEnable() {
             refresh();
         }
     });
+    addMenu(false);
 }
 
 function displayDisable() {
@@ -24,10 +73,11 @@ function displayDisable() {
             refresh();
         }
     });
+    addMenu(false);
 }
 
 function enable() {
-    chrome.storage.sync.set({'tocs_toggle': true}, function () {
+    chrome.storage.sync.set({ 'tocs_toggle': true }, function () {
     });
     if (!chrome.browserAction) return;
     chrome.browserAction.setIcon({
@@ -35,7 +85,7 @@ function enable() {
     });
 }
 function disable() {
-    chrome.storage.sync.set({'tocs_toggle': false}, function () {
+    chrome.storage.sync.set({ 'tocs_toggle': false }, function () {
     });
     if (!chrome.browserAction) return;
     chrome.browserAction.setIcon({

--- a/table-of-contents-sidebar/background.js
+++ b/table-of-contents-sidebar/background.js
@@ -1,4 +1,3 @@
-
 //isMenuCreated: true: have been created
 function addMenu(isMenuCreated) {
     if (!chrome.contextMenus) return;
@@ -22,7 +21,9 @@ function addMenu(isMenuCreated) {
         chrome.contextMenus.update("menu1", {
             title: scrollMsg,
             onclick: function () {
-                chrome.storage.sync.set({ 'scroll_effect': !items.scroll_effect }, function () {
+                chrome.storage.sync.set({
+                    'scroll_effect': !items.scroll_effect
+                }, function () {
                     addMenu(true);
                     refresh();
                 });
@@ -37,7 +38,9 @@ function addMenu(isMenuCreated) {
         chrome.contextMenus.update("menu2", {
             title: tooltipMsg,
             onclick: function () {
-                chrome.storage.sync.set({ 'show_tooltip': !items.show_tooltip }, function () {
+                chrome.storage.sync.set({
+                    'show_tooltip': !items.show_tooltip
+                }, function () {
                     addMenu(true);
                     refresh();
                 });
@@ -77,16 +80,19 @@ function displayDisable() {
 }
 
 function enable() {
-    chrome.storage.sync.set({ 'tocs_toggle': true }, function () {
-    });
+    chrome.storage.sync.set({
+        'tocs_toggle': true
+    }, function () {});
     if (!chrome.browserAction) return;
     chrome.browserAction.setIcon({
         path: "images/ic_enable.png"
     });
 }
+
 function disable() {
-    chrome.storage.sync.set({ 'tocs_toggle': false }, function () {
-    });
+    chrome.storage.sync.set({
+        'tocs_toggle': false
+    }, function () {});
     if (!chrome.browserAction) return;
     chrome.browserAction.setIcon({
         path: "images/ic_disable.png"
@@ -120,4 +126,20 @@ function getHostname(href) {
     l.href = href;
     return l.hostname;
 }
+//实际的作用是生成右键菜单
 checkToggle();
+
+function toggleToc() {
+    chrome.tabs.query({
+        active: true,
+        currentWindow: true
+    }, function (tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {
+                type: "toggleToc"
+            },
+            function (response) {;
+            });
+    });
+}
+
+chrome.browserAction.onClicked.addListener(tab => toggleToc())


### PR DESCRIPTION
It will take a long time to scroll when the page is long and the tooltips is annoying sometimes.
So add two menu items, one to control page scrolling effect, another to control showing tooltip or not .

页面很长的时候滚动时间太长, tooltip有时候也比较烦人, 所以增加了两个菜单, 用来控制是否有滚动效果和是否显示tooltip